### PR TITLE
Update to tests wrt to use of `test_solver`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,8 @@ jobs:
           - "1.6"
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          # - macOS-latest
+          # - windows-latest
         arch:
           - x64
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -24,9 +24,10 @@ julia = "1.6"
 
 [extras]
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
+POMDPSolve = "a575d7f4-a5df-53f5-8ba4-9d691c1ba8ff"
 QuickPOMDPs = "8af83fb2-a731-493c-9049-9e19dbce6165"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["POMDPModels", "Suppressor", "QuickPOMDPs", "Test"]
+test = ["POMDPModels", "Suppressor", "QuickPOMDPs", "Test", "POMDPSolve"]


### PR DESCRIPTION
Changed from using `test_solver` to compare values for a single simulation after generating the policy to be a functional test. 

Added in a test for BabyPOMDP to compare values of the policy at different beliefs against a POMDPSolve (also incremental pruning) policy.

Updated CI to only run on ubuntu. There should not be OS specific issues in this package.